### PR TITLE
feat: added meta image

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -425,6 +425,7 @@ module.exports = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
+    image: 'img/favicon.png',
     metadatas: [
       {
         name: "description",


### PR DESCRIPTION
## Issue
Currently no [meta images](https://docusaurus.io/docs/api/themes/configuration#meta-image) have been set for the https://apisix.apache.org/ as can be found below:

![image](https://user-images.githubusercontent.com/53327173/118563712-af57bf80-b78c-11eb-817c-67697bfb23da.png)

## Feature
Adding one will show a preview meta image with the meta description when users share the website links accross different social handles.

![apisix-meta-image-demo](https://user-images.githubusercontent.com/53327173/118564590-39ecee80-b78e-11eb-8619-38e6d69f042c.png)
